### PR TITLE
Receive `UserDevice` data from app-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [1.0.15] - 2018-12-13
+
+### Added
+
+- OiCyCommandCreator can now have access to the user's device information.
 - CircleCI support
 
 ## [1.0.14] - 2018-12-12

--- a/OicyLambdaRunner.ts
+++ b/OicyLambdaRunner.ts
@@ -45,7 +45,10 @@ const OicyLambdaRunner = async (event, commandCreator: OicyCommandCreator) => {
   const params = event.params
   const targetSubMrrKeys = stringToObject(event.targetSubMrrKeys || {})
   const changedServingsForRate = Number(event.changedServingsForRate) || 1
-  const device = Device.convert(event.device || {})
+  let device: Device | null = null
+  if (event.device) {
+    device = Device.convert(stringToObject(event.device))
+  }
   const request = OicyRequest.create(mrr, params, targetSubMrrKeys, changedServingsForRate, hrr, device)
   const callback = event.callback
 

--- a/OicyLambdaRunner.ts
+++ b/OicyLambdaRunner.ts
@@ -1,6 +1,6 @@
 import { Hrr } from "./Hrr"
 import { Mrr } from "./Mrr"
-import { OicyRequest } from "./OicyRequest"
+import { OicyRequest, Device } from "./OicyRequest"
 import { OicyCommand, OicyResponse, OicyTriggerCreator } from "./OicyResponse"
 import { OicyCommandCreator } from "./OicyCommandCreator"
 
@@ -45,7 +45,8 @@ const OicyLambdaRunner = async (event, commandCreator: OicyCommandCreator) => {
   const params = event.params
   const targetSubMrrKeys = stringToObject(event.targetSubMrrKeys || {})
   const changedServingsForRate = Number(event.changedServingsForRate) || 1
-  const request = OicyRequest.create(mrr, params, targetSubMrrKeys, changedServingsForRate, hrr)
+  const device = Device.convert(event.device || {})
+  const request = OicyRequest.create(mrr, params, targetSubMrrKeys, changedServingsForRate, hrr, device)
   const callback = event.callback
 
   if (callback == "triggers") {

--- a/OicyLambdaRunner.ts
+++ b/OicyLambdaRunner.ts
@@ -1,6 +1,6 @@
 import { Hrr } from "./Hrr"
 import { Mrr } from "./Mrr"
-import { OicyRequest, Device } from "./OicyRequest"
+import { OicyRequest, UserDevice } from "./OicyRequest"
 import { OicyCommand, OicyResponse, OicyTriggerCreator } from "./OicyResponse"
 import { OicyCommandCreator } from "./OicyCommandCreator"
 
@@ -45,9 +45,9 @@ const OicyLambdaRunner = async (event, commandCreator: OicyCommandCreator) => {
   const params = event.params
   const targetSubMrrKeys = stringToObject(event.targetSubMrrKeys || {})
   const changedServingsForRate = Number(event.changedServingsForRate) || 1
-  let device: Device | null = null
+  let device: UserDevice | null = null
   if (event.device) {
-    device = Device.convert(stringToObject(event.device))
+    device = UserDevice.convert(stringToObject(event.device))
   }
   const request = OicyRequest.create(mrr, params, targetSubMrrKeys, changedServingsForRate, hrr, device)
   const callback = event.callback

--- a/OicyRequest.ts
+++ b/OicyRequest.ts
@@ -1,14 +1,14 @@
 import { Mrr } from "./Mrr"
 import { Hrr } from "./Hrr"
 
-class Device {
+class UserDevice {
   readonly deviceId: string
-  readonly typeNumber: string
-  readonly modelName: string
+  readonly deviceTypeNumber: string
+  readonly deviceModelName: string
   readonly nickName: string
 
-  static convert(obj): Device {
-    const self = new Device()
+  static convert(obj): UserDevice {
+    const self = new UserDevice()
     Object.keys(obj).forEach(k => (self[k] = obj[k]))
     return self
   }
@@ -40,7 +40,7 @@ class OicyRequest {
    */
   readonly changedServingsForRate: number
   readonly hrr: Hrr | null
-  readonly device: Device | null
+  readonly device: UserDevice | null
 
   /**
    * <b>!!PACKAGE PRIVATE!! DO NOT CALL THIS.</b>
@@ -51,7 +51,7 @@ class OicyRequest {
     targetSubMrrKeys: TargetSubMrrKeys,
     changedServingsForRate: number,
     hrr: Hrr | null,
-    device: Device | null
+    device: UserDevice | null
   ) {
     this.targetSubMrrKeys = targetSubMrrKeys
     this.mrr = mrr
@@ -70,7 +70,7 @@ class OicyRequest {
     targetSubMrrKeysObj: any,
     changedServingsForRate: number,
     hrr: Hrr | null,
-    device: Device | null
+    device: UserDevice | null
   ): OicyRequest {
     let nodeIds = []
     let edgeIds = []
@@ -82,4 +82,4 @@ class OicyRequest {
     return new this(mrr, params, targetSubMrrKeys, changedServingsForRate, hrr, device)
   }
 }
-export { OicyRequest, TargetSubMrrKeys, Device }
+export { OicyRequest, TargetSubMrrKeys, UserDevice }

--- a/OicyRequest.ts
+++ b/OicyRequest.ts
@@ -5,7 +5,7 @@ class UserDevice {
   readonly deviceId: string
   readonly deviceTypeNumber: string
   readonly deviceModelName: string
-  readonly nickName: string
+  readonly nickname: string
 
   static convert(obj): UserDevice {
     const self = new UserDevice()

--- a/OicyRequest.ts
+++ b/OicyRequest.ts
@@ -1,6 +1,19 @@
 import { Mrr } from "./Mrr"
 import { Hrr } from "./Hrr"
 
+class Device {
+  readonly deviceId: string
+  readonly typeNumber: string
+  readonly modelName: string
+  readonly nickName: string
+
+  static convert(obj): Device {
+    const self = new Device()
+    Object.keys(obj).forEach(k => (self[k] = obj[k]))
+    return self
+  }
+}
+
 /**
  * Target nodes & edges for this DeviceAction
  */
@@ -27,6 +40,7 @@ class OicyRequest {
    */
   readonly changedServingsForRate: number
   readonly hrr: Hrr | null
+  readonly device: Device | null
 
   /**
    * <b>!!PACKAGE PRIVATE!! DO NOT CALL THIS.</b>
@@ -36,13 +50,15 @@ class OicyRequest {
     params: any,
     targetSubMrrKeys: TargetSubMrrKeys,
     changedServingsForRate: number,
-    hrr: Hrr | null
+    hrr: Hrr | null,
+    device: Device | null
   ) {
     this.targetSubMrrKeys = targetSubMrrKeys
     this.mrr = mrr
     this.params = params
     this.changedServingsForRate = changedServingsForRate
     this.hrr = hrr
+    this.device = device
   }
 
   /**
@@ -53,7 +69,8 @@ class OicyRequest {
     params: any,
     targetSubMrrKeysObj: any,
     changedServingsForRate: number,
-    hrr: Hrr | null
+    hrr: Hrr | null,
+    device: Device | null
   ): OicyRequest {
     let nodeIds = []
     let edgeIds = []
@@ -62,7 +79,7 @@ class OicyRequest {
       edgeIds = targetSubMrrKeysObj.edgeIds
     }
     const targetSubMrrKeys = new TargetSubMrrKeys(nodeIds, edgeIds)
-    return new this(mrr, params, targetSubMrrKeys, changedServingsForRate, hrr)
+    return new this(mrr, params, targetSubMrrKeys, changedServingsForRate, hrr, device)
   }
 }
-export { OicyRequest, TargetSubMrrKeys }
+export { OicyRequest, TargetSubMrrKeys, Device }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oicy-command-creator",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "main": "index.ts",
   "repository": {
     "type": "git",

--- a/test/OicyLambdaRunner.test.ts
+++ b/test/OicyLambdaRunner.test.ts
@@ -46,7 +46,6 @@ describe("OicyLambdaRunner", () => {
 
     const ret = await OicyLambdaRunner(event, new TestCommandCreator())
     assert.deepEqual(ret.view, {})
-    console.log(ret.data)
     assert.equal(ret.data, "t=OCY-001&m=OiCyDevice")
   })
 })

--- a/test/OicyLambdaRunner.test.ts
+++ b/test/OicyLambdaRunner.test.ts
@@ -1,0 +1,44 @@
+import { describe, it } from "mocha"
+import assert from "power-assert"
+
+import { OicyLambdaRunner } from "../OicyLambdaRunner"
+import { OicyCommandCreator } from "../OicyCommandCreator"
+import { OicyRequest } from "../OicyRequest"
+import { OicyTrigger, OicyCommand, OicyTriggerCreator } from "../OicyResponse"
+
+class TestCommandCreator implements OicyCommandCreator {
+  triggers(request: OicyRequest, oicyTriggerCreator: OicyTriggerCreator): OicyTrigger[] {
+    return []
+  }
+
+  create(request: OicyRequest, oicyCommand: OicyCommand): void {
+    if (request.device) {
+      oicyCommand.data = `t=${request.device.typeNumber}`
+    }
+  }
+}
+
+describe("OicyLambdaRunner", () => {
+  it("OiCyRequest does not have any device info", async () => {
+    const event = {
+      callback: "create",
+      mrr: { nodes: [], edges: [] },
+    }
+
+    const ret = await OicyLambdaRunner(event, new TestCommandCreator())
+    assert.deepEqual(ret.view, {})
+    assert.equal(ret.data, undefined)
+  })
+
+  it("OiCyRequest has the device info", async () => {
+    const event = {
+      callback: "create",
+      device: JSON.stringify({ typeNumber: "OCY-001" }),
+      mrr: { nodes: [], edges: [] },
+    }
+
+    const ret = await OicyLambdaRunner(event, new TestCommandCreator())
+    assert.deepEqual(ret.view, {})
+    assert.equal(ret.data, "t=OCY-001")
+  })
+})

--- a/test/OicyLambdaRunner.test.ts
+++ b/test/OicyLambdaRunner.test.ts
@@ -7,13 +7,20 @@ import { OicyRequest } from "../OicyRequest"
 import { OicyTrigger, OicyCommand, OicyTriggerCreator } from "../OicyResponse"
 
 class TestCommandCreator implements OicyCommandCreator {
-  triggers(request: OicyRequest, oicyTriggerCreator: OicyTriggerCreator): OicyTrigger[] {
+  triggers(request: OicyRequest, triggerCreator: OicyTriggerCreator): OicyTrigger[] {
     return []
   }
 
-  create(request: OicyRequest, oicyCommand: OicyCommand): void {
+  create(request: OicyRequest, command: OicyCommand): void {
     if (request.device) {
-      oicyCommand.data = `t=${request.device.typeNumber}`
+      let data: String[] = []
+      if (request.device.deviceTypeNumber) {
+        data.push(`t=${request.device.deviceTypeNumber}`)
+      }
+      if (request.device.deviceModelName) {
+        data.push(`m=${request.device.deviceModelName}`)
+      }
+      command.data = data.join("&")
     }
   }
 }
@@ -33,12 +40,13 @@ describe("OicyLambdaRunner", () => {
   it("OiCyRequest has the device info", async () => {
     const event = {
       callback: "create",
-      device: JSON.stringify({ typeNumber: "OCY-001" }),
+      device: JSON.stringify({ deviceTypeNumber: "OCY-001", deviceModelName: "OiCyDevice" }),
       mrr: { nodes: [], edges: [] },
     }
 
     const ret = await OicyLambdaRunner(event, new TestCommandCreator())
     assert.deepEqual(ret.view, {})
-    assert.equal(ret.data, "t=OCY-001")
+    console.log(ret.data)
+    assert.equal(ret.data, "t=OCY-001&m=OiCyDevice")
   })
 })


### PR DESCRIPTION
With this PR, `OicyCommandCreator` can receive `UserDevice` data such as `typeNumber` and `modelName`.  Oicy developers will be able to choose the supported MRR and device actions based on the device model and type.

