### PR TITLE
:+1: version 3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oicy-command-creator",
-  "version": "1.0.16",
+  "version": "3.0.1",
   "main": "index.ts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
v1からv3に飛びますが、MRRのフォーマットに強く依存するので、MRRのメジャーバージョンに合わせてv3にするようにします