### PR TITLE
Bump Circle CI node version to v12.xx

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8.10
+      - image: circleci/node:12.14
 
     working_directory: ~/repo
 


### PR DESCRIPTION
Since nodev8 is no longer supported on AWS lambda, I would like to bump the version up to v12.x (the current major supported version)

