### PR TITLE
Allow Triggers to include any arbitrary data in its response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.1] - 2020-02-06
+
+### Changed
+
+- OiCyTrigger now can include any arbitrary data
+
 ## [3.1.0] - 2020-02-06
 
 ### Added

--- a/OicyResponse.ts
+++ b/OicyResponse.ts
@@ -12,6 +12,7 @@ export class OicyTrigger extends OicyResponse {
   linkText?: string
   readonly targetSubMrrKeys: TargetSubMrrKeys
   callback?: string
+  [key: string]: any
 
   /**
    * <b>!!PACKAGE PRIVATE!! DO NOT CALL THIS.</b>

--- a/OicyResponse.ts
+++ b/OicyResponse.ts
@@ -36,7 +36,7 @@ export class OicyTrigger extends OicyResponse {
 export class OicyTriggerSet {
   triggers: OicyTrigger[]
   constructor() {
-    this.triggers = new Array<OicyTrigger>();
+    this.triggers = new Array<OicyTrigger>()
   }
 }
 export enum HttpMethod {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oicy-command-creator",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "main": "dist/index.js",
   "files": ["dist"],
   "repository": {

--- a/test/OicyLambdaRunner.test.ts
+++ b/test/OicyLambdaRunner.test.ts
@@ -9,9 +9,10 @@ import { OicyTriggerSet, OicyCommand, OicyTriggerCreator } from "../OicyResponse
 class TestCommandCreator implements OicyCommandCreator {
   triggers(_request: OicyRequest, triggerCreator: OicyTriggerCreator): OicyTriggerSet {
     const triggerSet = new OicyTriggerSet()
-    const oicyTrigger = triggerCreator.create([], []);
-    triggerSet.triggers.push(oicyTrigger);
+    const oicyTrigger = triggerCreator.create([], [])
+    triggerSet.triggers.push(oicyTrigger)
     oicyTrigger.callback = "confirm"
+    oicyTrigger.mydata = "mydata"
     return triggerSet
   }
 
@@ -72,6 +73,7 @@ describe("OicyLambdaRunner", () => {
     if (ret instanceof OicyTriggerSet) {
       assert.equal(ret.triggers.length, 1)
       assert.equal(ret.triggers[0].callback, "confirm")
+      assert.equal(ret.triggers[0].mydata, "mydata")
     } else {
       assert.fail("ret is not OicyTriggerSet")
     }


### PR DESCRIPTION
With this change, makers can include any arbitrary data in the Triggers response, so that we can pass extra information from triggers to their clients.

One expected situation is to group ingredients into `ingredientGroups` and set them as `trigger.ingredientGroups`.

