### PR TITLE
Make MRR optional

### DIFF
--- a/OicyLambdaRunner.ts
+++ b/OicyLambdaRunner.ts
@@ -11,7 +11,10 @@ export const OicyLambdaRunner = async (
   event: any,
   commandCreator: OicyCommandCreator
 ): Promise<OicyTriggerSet | OicyResponse | OicyCommand> => {
-  const mrr = Mrr.convert(JSON.parse(event.mrr), { withNodeNormalizing: true })
+  let mrr: Mrr | undefined
+  if (event.mrr) {
+    mrr = Mrr.convert(JSON.parse(event.mrr), { withNodeNormalizing: true })
+  }
   const hrr = event.hrr ? Hrr.convert(JSON.parse(event.hrr)) : undefined
   const params = event.params
   const targetSubMrrKeys = event.targetSubMrrKeys ? JSON.parse(event.targetSubMrrKeys) : {}

--- a/OicyRequest.ts
+++ b/OicyRequest.ts
@@ -29,17 +29,13 @@ export class TargetSubMrrKeys {
 }
 
 export class OicyRequest {
-  /**
-   * Local code (e.g. ja-JP)
-   */
-  readonly lcid!: string
   readonly params: any
-  readonly mrr: Mrr
-  readonly targetSubMrrKeys: TargetSubMrrKeys
+  readonly mrr?: Mrr
+  readonly targetSubMrrKeys?: TargetSubMrrKeys
   /**
    * The ServingsForRate is changed by the user. Default value is 1
    */
-  readonly changedServingsForRate: number
+  readonly changedServingsForRate?: number
   readonly hrr?: Hrr
   readonly device?: UserDevice
 
@@ -47,16 +43,16 @@ export class OicyRequest {
    * <b>!!PACKAGE PRIVATE!! DO NOT CALL THIS.</b>
    */
   constructor(
-    mrr: Mrr,
     params: any,
-    targetSubMrrKeys: TargetSubMrrKeys,
-    changedServingsForRate: number,
+    mrr?: Mrr,
+    targetSubMrrKeys?: TargetSubMrrKeys,
+    changedServingsForRate?: number,
     hrr?: Hrr,
     device?: UserDevice
   ) {
-    this.targetSubMrrKeys = targetSubMrrKeys
-    this.mrr = mrr
     this.params = params
+    this.mrr = mrr
+    this.targetSubMrrKeys = targetSubMrrKeys
     this.changedServingsForRate = changedServingsForRate
     this.hrr = hrr
     this.device = device
@@ -66,10 +62,10 @@ export class OicyRequest {
    * <b>!!PACKAGE PRIVATE!! DO NOT CALL THIS.</b>
    */
   static create(
-    mrr: Mrr,
     params: any,
-    targetSubMrrKeysObj: any,
-    changedServingsForRate: number,
+    mrr?: Mrr,
+    targetSubMrrKeysObj?: any,
+    changedServingsForRate?: number,
     hrr?: Hrr,
     device?: UserDevice
   ): OicyRequest {
@@ -80,6 +76,6 @@ export class OicyRequest {
       edgeIds = targetSubMrrKeysObj.edgeIds
     }
     const targetSubMrrKeys = new TargetSubMrrKeys(nodeIds, edgeIds)
-    return new this(mrr, params, targetSubMrrKeys, changedServingsForRate, hrr, device)
+    return new this(params, mrr, targetSubMrrKeys, changedServingsForRate, hrr, device)
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oicy-command-creator",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "main": "dist/index.js",
   "files": [
     "dist"

--- a/test/OicyLambdaRunner.test.ts
+++ b/test/OicyLambdaRunner.test.ts
@@ -65,7 +65,7 @@ describe("OicyLambdaRunner", () => {
   it("OiCyRequest has triggers", async () => {
     const event = {
       callback: "triggers",
-      device: JSON.stringify({ deviceTypeNumber: "OCY-001", deviceModelName: "OiCyDevice" }),
+      device: { deviceTypeNumber: "OCY-001", deviceModelName: "OiCyDevice" },
       mrr: JSON.stringify({ nodes: [], edges: [] }),
     }
 
@@ -76,6 +76,22 @@ describe("OicyLambdaRunner", () => {
       assert.equal(ret.triggers[0].mydata, "mydata")
     } else {
       assert.fail("ret is not OicyTriggerSet")
+    }
+  })
+
+  it("OiCyRequest doesn't have MRR", async () => {
+    const event = {
+      callback: "create",
+      device: { deviceTypeNumber: "OCY-001", deviceModelName: "OiCyDevice" },
+      mrr: "",
+    }
+
+    const ret = await OicyLambdaRunner(event, new TestCommandCreator())
+    if (ret instanceof OicyCommand) {
+      assert.deepEqual(ret.view, {})
+      assert.equal(ret.data, "t=OCY-001&m=OiCyDevice")
+    } else {
+      assert.fail("ret is not OicyCommand")
     }
   })
 })


### PR DESCRIPTION
In some situations, we want to call oicy command creator from clients without MRR.

In this case the responsibility of command creator is to transform the params from any format provided from clients to a certain format that the maker APIs can support.

